### PR TITLE
Fix: Replace Material Icons text with SVGs on services page

### DIFF
--- a/services.html
+++ b/services.html
@@ -58,15 +58,21 @@
                 </p>
 <div class="mt-4 space-y-2">
 <div class="flex items-center gap-3">
-<span class="material-icons text-[var(--primary-color)]">check_circle</span>
+<svg class="h-6 w-6 text-[var(--primary-color)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+</svg>
 <span class="font-medium">Certified Inspectors</span>
 </div>
 <div class="flex items-center gap-3">
-<span class="material-icons text-[var(--primary-color)]">check_circle</span>
+<svg class="h-6 w-6 text-[var(--primary-color)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+</svg>
 <span class="font-medium">Detailed Reports</span>
 </div>
 <div class="flex items-center gap-3">
-<span class="material-icons text-[var(--primary-color)]">check_circle</span>
+<svg class="h-6 w-6 text-[var(--primary-color)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+</svg>
 <span class="font-medium">Regulation Compliance</span>
 </div>
 </div>
@@ -85,15 +91,21 @@
                 </p>
 <div class="mt-4 space-y-2">
 <div class="flex items-center gap-3">
-<span class="material-icons text-[var(--primary-color)]">check_circle</span>
+<svg class="h-6 w-6 text-[var(--primary-color)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+</svg>
 <span class="font-medium">New System Installation</span>
 </div>
 <div class="flex items-center gap-3">
-<span class="material-icons text-[var(--primary-color)]">check_circle</span>
+<svg class="h-6 w-6 text-[var(--primary-color)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+</svg>
 <span class="font-medium">Efficient Repairs</span>
 </div>
 <div class="flex items-center gap-3">
-<span class="material-icons text-[var(--primary-color)]">check_circle</span>
+<svg class="h-6 w-6 text-[var(--primary-color)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+</svg>
 <span class="font-medium">High-Quality Materials</span>
 </div>
 </div>
@@ -112,15 +124,21 @@
                 </p>
 <div class="mt-4 space-y-2">
 <div class="flex items-center gap-3">
-<span class="material-icons text-[var(--primary-color)]">check_circle</span>
+<svg class="h-6 w-6 text-[var(--primary-color)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+</svg>
 <span class="font-medium">24/7 Availability</span>
 </div>
 <div class="flex items-center gap-3">
-<span class="material-icons text-[var(--primary-color)]">check_circle</span>
+<svg class="h-6 w-6 text-[var(--primary-color)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+</svg>
 <span class="font-medium">Rapid Response Team</span>
 </div>
 <div class="flex items-center gap-3">
-<span class="material-icons text-[var(--primary-color)]">check_circle</span>
+<svg class="h-6 w-6 text-[var(--primary-color)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+</svg>
 <span class="font-medium">Damage Prevention</span>
 </div>
 </div>


### PR DESCRIPTION
I replaced the lingering 'check_circle' text (from the removed Material Icons font) with appropriate SVG checkmark icons in `services.html`.