### PR TITLE
Fix: Remove unused hamburger menu from contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -38,13 +38,6 @@
 <svg class="h-8 w-8 text-[var(--brand-secondary)]" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L8.99 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1h-2v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.62-1.24 4.97-3.1 6.51z"></path></svg>
 <span class="text-xl font-bold text-black">Whidbey Septic</span>
 </a>
-<button class="md:hidden">
-<svg fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-<line x1="4" x2="20" y1="12" y2="12"></line>
-<line x1="4" x2="20" y1="6" y2="6"></line>
-<line x1="4" x2="20" y1="18" y2="18"></line>
-</svg>
-</button>
 </div>
 </header>
 <main class="flex-grow">


### PR DESCRIPTION
Removed the non-functional hamburger menu icon from the header of `contact.html`.