### PR TITLE
feat: Replace logo and name with circular image

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -35,8 +35,7 @@
 <header class="bg-white/80 backdrop-blur-sm sticky top-0 z-10">
 <div class="flex items-center p-4 justify-between max-w-7xl mx-auto">
 <a href="/" class="flex items-center gap-2 text-white">
-<svg class="h-8 w-8 text-[var(--brand-secondary)]" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L8.99 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1h-2v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.62-1.24 4.97-3.1 6.51z"></path></svg>
-<span class="text-xl font-bold text-black">Whidbey Septic</span>
+<img src="/assets/whidbeysepticlogo.png" class="h-12 w-12 rounded-full" />
 </a>
 </div>
 </header>

--- a/index.html
+++ b/index.html
@@ -28,8 +28,7 @@
 <div class="@container">
 <div class="relative flex min-h-[60vh] md:min-h-screen flex-col gap-6 bg-cover bg-center bg-no-repeat items-start justify-center text-center px-4 py-16" style='background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6) 0%, rgba(0, 0, 0, 0.2) 100%), url("https://lh3.googleusercontent.com/aida-public/AB6AXuApd7UYnIZgdFfbESBMPJ3s4ms9dv2hYmnwX41e9cbHeKaWJ07E9rz9xGVZIxc4FCutIvtWYqGzoHQgaWxlpYmPphiWVU2-4Xx36z7pM6-S8HJNRzdrasBw_c8zHu6MSQcX5ZA8wrfJcJHl2sMroEoXH4tSk7fwdrMwe85PzPN9kgkzMkgPtRGa1EouJrNHRvWBGpSOU8DddDzBJciHKd1Ae6mw8sGr-8pt4Z9NsQ3U_5Uung0i7UopaX8arByRNv-krYQHPKKVg4Q");'>
 <a href="/" class="absolute top-4 left-4 flex items-center gap-2 text-white">
-<svg class="h-8 w-8 text-[var(--brand-secondary)]" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L8.99 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1h-2v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.62-1.24 4.97-3.1 6.51z"></path></svg>
-<span class="text-xl font-bold">Whidbey Septic</span>
+<img src="/assets/whidbeysepticlogo.png" class="h-12 w-12 rounded-full" />
 </a>
 <div class="flex flex-col gap-4 text-center items-center w-full max-w-3xl mx-auto">
 <h1 class="text-white text-5xl md:text-7xl font-extrabold leading-tight tracking-tight">


### PR DESCRIPTION
- Replaced the SVG logo and 'Whidbey Septic' text with the new logo image on the main home page and the contact page.
- Cropped the logo into a circle using the `rounded-full` class.