### PR TITLE
feat: Zoom in on logo

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -35,7 +35,9 @@
 <header class="bg-white/80 backdrop-blur-sm sticky top-0 z-10">
 <div class="flex items-center p-4 justify-between max-w-7xl mx-auto">
 <a href="/" class="flex items-center gap-2 text-white">
-<img src="/assets/whidbeysepticlogo.png" class="h-12 w-12 rounded-full" />
+<div class="h-12 w-12 rounded-full overflow-hidden">
+<img src="/assets/whidbeysepticlogo.png" class="w-full h-full object-cover" />
+</div>
 </a>
 </div>
 </header>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,9 @@
 <div class="@container">
 <div class="relative flex min-h-[60vh] md:min-h-screen flex-col gap-6 bg-cover bg-center bg-no-repeat items-start justify-center text-center px-4 py-16" style='background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6) 0%, rgba(0, 0, 0, 0.2) 100%), url("https://lh3.googleusercontent.com/aida-public/AB6AXuApd7UYnIZgdFfbESBMPJ3s4ms9dv2hYmnwX41e9cbHeKaWJ07E9rz9xGVZIxc4FCutIvtWYqGzoHQgaWxlpYmPphiWVU2-4Xx36z7pM6-S8HJNRzdrasBw_c8zHu6MSQcX5ZA8wrfJcJHl2sMroEoXH4tSk7fwdrMwe85PzPN9kgkzMkgPtRGa1EouJrNHRvWBGpSOU8DddDzBJciHKd1Ae6mw8sGr-8pt4Z9NsQ3U_5Uung0i7UopaX8arByRNv-krYQHPKKVg4Q");'>
 <a href="/" class="absolute top-4 left-4 flex items-center gap-2 text-white">
-<img src="/assets/whidbeysepticlogo.png" class="h-12 w-12 rounded-full" />
+<div class="h-12 w-12 rounded-full overflow-hidden">
+<img src="/assets/whidbeysepticlogo.png" class="w-full h-full object-cover" />
+</div>
 </a>
 <div class="flex flex-col gap-4 text-center items-center w-full max-w-3xl mx-auto">
 <h1 class="text-white text-5xl md:text-7xl font-extrabold leading-tight tracking-tight">


### PR DESCRIPTION
- Used a container with `overflow-hidden` and `rounded-full` to crop the logo.
- Made the image larger than the container and centered it to zoom in on the logo.