### PR TITLE
feat: Increase logo size on desktop and mobile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,11 @@
+.logo-size {
+  height: 4rem; /* 64px, h-16 */
+  width: 4rem; /* 64px, w-16 */
+}
+
+@media (min-width: 768px) {
+  .logo-size {
+    height: 8rem; /* 128px, h-32 */
+    width: 8rem; /* 128px, w-32 */
+  }
+}

--- a/contact/index.html
+++ b/contact/index.html
@@ -6,6 +6,7 @@
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
 <link href="https://fonts.googleapis.com/css2?display=swap&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900&amp;family=Public+Sans%3Awght%40400%3B500%3B700%3B900" rel="stylesheet"/>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link rel="stylesheet" href="/assets/css/style.css">
 <link rel="icon" href="/assets/whidbeyisland.png">
 <title>Whidbey Septic - Contact</title>
 <style type="text/tailwindcss">
@@ -35,7 +36,7 @@
 <header class="bg-white/80 backdrop-blur-sm sticky top-0 z-10">
 <div class="flex items-center p-4 justify-between max-w-7xl mx-auto">
 <a href="/" class="flex items-center gap-2 text-white">
-<div class="h-12 w-12 rounded-full overflow-hidden">
+<div class="logo-size rounded-full overflow-hidden">
 <img src="/assets/whidbeysepticlogo.png" class="w-full h-full object-cover" />
 </div>
 </a>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 <title>Whidbey Septic - Home</title>
 <link rel="icon" href="/assets/whidbeyisland.png">
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link rel="stylesheet" href="/assets/css/style.css">
 <style type="text/tailwindcss">
       :root {
         --brand-primary: #0277bd;--brand-secondary: #2e7d32;--accent-earthy: #8d6e63;--neutral-light: #f5f5f5;
@@ -28,7 +29,7 @@
 <div class="@container">
 <div class="relative flex min-h-[60vh] md:min-h-screen flex-col gap-6 bg-cover bg-center bg-no-repeat items-start justify-center text-center px-4 py-16" style='background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6) 0%, rgba(0, 0, 0, 0.2) 100%), url("https://lh3.googleusercontent.com/aida-public/AB6AXuApd7UYnIZgdFfbESBMPJ3s4ms9dv2hYmnwX41e9cbHeKaWJ07E9rz9xGVZIxc4FCutIvtWYqGzoHQgaWxlpYmPphiWVU2-4Xx36z7pM6-S8HJNRzdrasBw_c8zHu6MSQcX5ZA8wrfJcJHl2sMroEoXH4tSk7fwdrMwe85PzPN9kgkzMkgPtRGa1EouJrNHRvWBGpSOU8DddDzBJciHKd1Ae6mw8sGr-8pt4Z9NsQ3U_5Uung0i7UopaX8arByRNv-krYQHPKKVg4Q");'>
 <a href="/" class="absolute top-4 left-4 flex items-center gap-2 text-white">
-<div class="h-12 w-12 rounded-full overflow-hidden">
+<div class="logo-size rounded-full overflow-hidden">
 <img src="/assets/whidbeysepticlogo.png" class="w-full h-full object-cover" />
 </div>
 </a>


### PR DESCRIPTION
- Created a new CSS class `.logo-size` to control the logo size.
- Increased the logo size on mobile to `h-16 w-16`.
- Increased the logo size on desktop to `md:h-32 md:w-32`.
- Applied the new class to the logo on the Home and Contact pages.