### PR TITLE
feat: replace services install/repair photo

### DIFF
--- a/services/index.html
+++ b/services/index.html
@@ -80,7 +80,7 @@
 </section>
 <section class="md:flex md:flex-row md:gap-8">
 <div class="overflow-hidden rounded-lg md:w-1/2 md:order-2">
-<img alt="Septic system installation" class="h-48 sm:h-64 md:h-72 w-full object-cover" src="https://lh3.googleusercontent.com/aida-public/AB6AXuBThnfGWJsgsNF_Lfy5N6HaRzIgrXHu2UTyDCGkaBNxbJ7HtocrbKC4xe-25uAVI4jAfcTvZbjDbRxBD--KAw3JtLw1Sa3NkX3K0iwbotjFUXhDv8XT5Ts3GrnnYEOXHEUh4a9k9xTJlDFiIi_F2YhcuN4sSPDhNSnU8kTK0Y92c92YDg28bH4bN_qrkTju8PXmRL-p1tVgGHfWKYXBC8Ibgi_fCyMjAH70ULoY_yrqdhOqqk5xRWveZjfCwiVSY6y4smeCnzhtZkA"/>
+<img alt="Septic system installation" class="h-48 sm:h-64 md:h-72 w-full object-cover" src="/assets/services_install.jpg"/>
 </div>
 <div class="mt-4 md:w-1/2 md:order-1">
 <h2 class="text-2xl font-bold">Installations &amp; Repairs</h2>


### PR DESCRIPTION
Replaced the placeholder image in the services page with the local photo from /assets/services_install.jpg.