### PR TITLE
fix: center buttons on mobile by wrapping in a div

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
                   A local, family &amp; veteran-owned business dedicated to keeping your systems running smoothly.
                 </h2>
 </div>
+<div class="w-full flex justify-center">
 <div class="flex-wrap gap-4 flex mt-6 justify-center">
 <a href="/services" class="flex min-w-[120px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-12 px-6 bg-[var(--brand-primary)] text-white text-base font-bold leading-normal tracking-wide shadow-lg transition-transform hover:scale-105">
 <span class="truncate">Our Services</span>
@@ -46,6 +47,7 @@
 <a href="/contact" class="flex min-w-[120px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-12 px-6 bg-white/90 text-[var(--neutral-dark)] text-base font-bold leading-normal tracking-wide shadow-lg backdrop-blur-sm transition-transform hover:scale-105">
 <span class="truncate">Contact Us</span>
 </a>
+</div>
 </div>
 </div>
 </div>


### PR DESCRIPTION
This commit wraps the 'Our Services' and 'Contact Us' buttons in a parent div with 'w-full', 'flex', and 'justify-center' classes to ensure they are centered on all screen sizes, especially on mobile devices.