### PR TITLE
Add 'Site Address' field to contact form

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -64,6 +64,10 @@
 <input class="form-input mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[var(--primary-color)] focus:ring focus:ring-[var(--primary-color)] focus:ring-opacity-50 h-14 p-4 text-base" placeholder="Your Name" type="text" name="name" required/>
 </label>
 <label class="block">
+<span class="sr-only">Site Address</span>
+<input class="form-input mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[var(--primary-color)] focus:ring focus:ring-[var(--primary-color)] focus:ring-opacity-50 h-14 p-4 text-base" placeholder="Site Address" type="text" name="site_address" required/>
+</label>
+<label class="block">
 <span class="sr-only">Your Email</span>
 <input class="form-input mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[var(--primary-color)] focus:ring focus:ring-[var(--primary-color)] focus:ring-opacity-50 h-14 p-4 text-base" placeholder="Your Email" type="email" name="email" required/>
 </label>
@@ -183,6 +187,7 @@
     event.preventDefault(); // Prevent default form submission
 
     const name = contactForm.elements['name'].value;
+    const siteAddress = contactForm.elements['site_address'].value;
     const email = contactForm.elements['email'].value;
     const phone = contactForm.elements['phone'].value;
     const message = contactForm.elements['message'].value;
@@ -191,6 +196,7 @@
                        `?subject=${encodeURIComponent('Contact Form Submission from ' + name)}` +
                        `&body=${encodeURIComponent(
                          `Name: ${name}\n` +
+                         `Site Address: ${siteAddress}\n` +
                          `Email: ${email}\n` +
                          `Phone: ${phone}\n\n` +
                          `Message:\n${message}`


### PR DESCRIPTION
This change adds a 'Site Address' field to the contact form on the contact page, as requested. The field is placed just below the 'Name' field and is required for form submission. The JavaScript handling the form submission has also been updated to include the site address in the email generated by the mailto: link. Visual verification was performed using Playwright and confirmed that the styling and placement are correct.

---
*PR created automatically by Jules for task [13897413194234733374](https://jules.google.com/task/13897413194234733374) started by @GoldenCaesar*